### PR TITLE
Include ELIXIR_ERL_OPTIONS in env.sh.eex guidance

### DIFF
--- a/getting-started/elixir.html.md.erb
+++ b/getting-started/elixir.html.md.erb
@@ -143,6 +143,7 @@ Then edit the generated `rel/env.sh.eex` file and add the following lines:
 ip=$(grep fly-local-6pn /etc/hosts | cut -f 1)
 export RELEASE_DISTRIBUTION=name
 export RELEASE_NODE=$FLY_APP_NAME@$ip
+export ELIXIR_ERL_OPTIONS="-proto_dist inet6_tcp"
 ```
 
 This names our Elixir node using the Fly application name and the internal IPv6 address. Make sure to deploy after making this change!


### PR DESCRIPTION
The default `env.sh.eex` file generated by `mix release.init` does not include the `ELIXIR_ERL_OPTIONS` export:

https://github.com/elixir-lang/elixir/blob/7e4fbe657dbf9c3e19e3d2bd6c17cc6d724b4710/lib/mix/lib/mix/tasks/release.init.ex#L59-L78

However, it appears this line is necessary in order for Fly networking to work properly (see https://community.fly.io/t/could-not-contact-remote-node-reason-nodedown-aborting/5221/3?u=derrickreimer).

Relatedly, I was not able to successfully start an IEx session (following [these instructions](https://fly.io/docs/getting-started/elixir/#iex-shell-into-your-running-app)) _until_ I made these updates to the `env.sh.eex` file. The instructions for changing `env.sh.eex` are listed _below_ the IEx instructions, so it might be trip-up point if folks are following this guide sequentially. I would recommend moving this portion higher in the guide, but have refrained from doing so in this PR, since that's a bigger structural change.

Thanks all!